### PR TITLE
remove Alien::LibGumbo as a runtime dependency

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -6,13 +6,12 @@ my $builder = Module::Build->new(
     module_name => 'HTML::Gumbo',
 
     configure_requires => {
-        'Alien::LibGumbo' => 0,
+        'Alien::LibGumbo' => 0.14,
     },
     build_requires => {
         'ExtUtils::CBuilder' => 0,
     },
     requires => {
-        'Alien::LibGumbo' => 0,
     },
 
     meta_merge => {

--- a/lib/HTML/Gumbo.pm
+++ b/lib/HTML/Gumbo.pm
@@ -4,7 +4,6 @@ use warnings;
 
 package HTML::Gumbo;
 
-use Alien::LibGumbo;
 our $VERSION = '0.13';
 
 require XSLoader;


### PR DESCRIPTION
If this PR is accepted:

https://github.com/ruz/Alien-LibGumbo/pull/3

This change will remove Alien::LibGumbo as a run-time dependency, which will be nice for distribution vendors.  This assumes that the next version of Alien::LibGumbo will be 0.14 and will include the above PR.
