### PR TITLE
tree_to_callback: don't check document nodes for void elements

### DIFF
--- a/lib/HTML/Gumbo.xs
+++ b/lib/HTML/Gumbo.xs
@@ -401,7 +401,7 @@ tree_to_callback(pTHX_ PerlHtmlGumboType type, GumboNode* node, void* ctx) {
     dSP;
     SV* cb = (SV*) ctx;
 
-    if ( type == PHG_ELEMENT_END && PHG_IS_VOID_ELEMENT(node->v.element.tag) )
+    if ( type == PHG_ELEMENT_END && node->type == GUMBO_NODE_ELEMENT && PHG_IS_VOID_ELEMENT(node->v.element.tag) )
         return;
 
     ENTER;


### PR DESCRIPTION
walk_tree() will call this with PHG_ELEMENT_END for both document
and element nodes, but only the latter ones have tag types defined.

This fixes test failures seen on 32-bit big endian systems
such as mips and powerpc, when a document node happened
to have a valid (void) tag code at the same offset, triggering
an early return.

Bug-Debian: https://bugs.debian.org/904914